### PR TITLE
Issue #39: Add continuous polar pan commands

### DIFF
--- a/icd_config.py
+++ b/icd_config.py
@@ -34,8 +34,10 @@ def int_to_bytes(num, num_bits=16, unsigned=True):
 
 class Command(Enum):
     HANDSHAKE = 0x0000
-    POLAR_PAN = 0x0001
+    POLAR_PAN_DISCRETE = 0x0001
     HOME = 0x0002
+    POLAR_PAN_CONTINUOUS_START = 0x0003
+    POLAR_PAN_CONTINUOUS_STOP = 0x0004
 
     def __int__(self):
         """

--- a/manual_interface.py
+++ b/manual_interface.py
@@ -163,16 +163,16 @@ class ManualInterface:
             # moves toward input direction by delta 10 (degrees)
             match direction:
                 case Direction.UP:
-                    Publisher.polar_pan(0, 10, 1000, 3000)
+                    Publisher.polar_pan_discrete(0, 10, 1000, 3000)
                     print("up")
                 case Direction.DOWN:
-                    Publisher.polar_pan(0, -10, 1000, 3000)
+                    Publisher.polar_pan_discrete(0, -10, 1000, 3000)
                     print("down")
                 case Direction.LEFT:
-                    Publisher.polar_pan(-10, 0, 1000, 3000)
+                    Publisher.polar_pan_discrete(-10, 0, 1000, 3000)
                     print("left")
                 case Direction.RIGHT:
-                    Publisher.polar_pan(10, 0, 1000, 3000)
+                    Publisher.polar_pan_discrete(10, 0, 1000, 3000)
                     print("right")
             
             self.rootWindow.after(self.move_delay_ms, lambda: self.keep_moving(direction)) # lambda used as function reference to execute when required

--- a/mock_operator.py
+++ b/mock_operator.py
@@ -7,7 +7,7 @@ class MyListener(stomp.ConnectionListener):
         print('received an error "%s"' % frame.body)
 
     def on_message(self, frame):
-        print('received a message "%s"' % frame.body)
+        print('received a message "%s"' % bytes(frame.body, 'utf-8'))
 
 conn = stomp.Connection()
 conn.set_listener(name='My listener', listener=MyListener())


### PR DESCRIPTION
This PR introduces implementations for the continuous polar pan commands. This does not introduce the actual usage of these functions in the manual interface.

- Added a start command for continuous polar pan
- Added a stop command for continuous polar pan
- Refactored existing polar pan function and variables to be labeled as polar pan discrete.
- Added support for empty payloads

closes #39 