### PR TITLE
Screen freeze bug fix - Issue 60

### DIFF
--- a/tracking/media_pipe/media_pipe_tracker.py
+++ b/tracking/media_pipe/media_pipe_tracker.py
@@ -79,6 +79,8 @@ class MediaPipeTracker(Tracker):
             return None, None
 
         bboxes = self.detectPerson(self.object_detector, frame)
+        if len(bboxes) < 1:
+            #This is for when there is no person in frame, we still want the video to show
+            cv2.imshow('Object Detection', frame)
         
-
         return bboxes, frame


### PR DESCRIPTION
# Description
Currently when a speaker moves completely off camera, the output of the video will "freeze" with them still in frame. The screen is not actually freezing the is occurring because the new "draw_visuals" function was moved inside of the director. When the speaker is not in frame the tracker will not return any bounding boxes, leading to the visuals no longer being maintained.

This commit fixes that by adding in an imshow for when the bounding boxes are empty. With this the visuals are no longer there, but we don't need them because no one is in frame. And this fixes the appearance of freezing.

# Metrics
- PR Confidence value: 5/5

