### PR TITLE
Issue 54: Migrate from ActiveMQ

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,3 @@
+# Publisher
+SOCKET_HOST = "localhost"
+SOCKET_PORT = 61616

--- a/connections.py
+++ b/connections.py
@@ -1,0 +1,137 @@
+from icd_config import int_to_bytes, bytes_to_int
+import socket
+import time
+import threading
+
+
+class Connection:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.is_connected = False
+        self.async_connect()
+        self.command_count = 0
+
+    def async_connect(self):
+        thread = threading.Thread(target=self.connect)
+        thread.start()
+
+    def connect(self):
+        raise NotImplementedError("connect method is not implemented")
+
+    def close_socket(self):
+        self.socket.close()
+        self.is_connected = False
+
+    def publish(self, command: int, payload: bytes = None):
+        """
+        Command ID      UINT32	Unique ID for individual commands
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        RESERVED     	UINT16	RESERVED
+        Command Value	UINT16	Command for device to carry out
+        Length	        UINT16	Length of Payload
+        Payload	        UINT8[]	Command Info
+        CRC	            UINT16	Checksum
+        """
+        # Get a unique, incrementing command id. Increment by 2, so that the response
+        # from the operator always returns odd command ids and the publisher always sends
+        # even command ids. Commands can be associated with each other by checking if they
+        # have the same modulus of 2.
+        command_id = self.command_count
+        self.command_count += 2
+
+        if payload != None:
+            payload_length = len(payload)
+        else:
+            payload_length = 0
+
+        # TODO: Implement checksum. May get removed
+        crc = int_to_bytes(0, num_bits=16, unsigned=True)
+
+        command_id = int_to_bytes(command_id, num_bits=32, unsigned=True)
+        reserved = int_to_bytes(0, num_bits=16, unsigned=True)
+        command = int_to_bytes(command, num_bits=16, unsigned=True)
+        payload_length = int_to_bytes(payload_length, num_bits=16, unsigned=True)
+
+        # Put header together
+        header = command_id + reserved + command + payload_length
+
+        # Put everything together 
+        body = header
+
+        if payload != None:
+            body += payload
+
+        body += crc
+
+        self.socket.send(body)
+        response = self.socket.recv(2048)
+        return response
+
+
+class OperatorConnection(Connection):
+    def connect(self):
+        while(True):
+            try:
+                self.socket.connect((self.host, self.port))
+                self.is_connected = True
+                print("Connected to socket: " + self.host + ":" + str(self.port))
+                break
+            except ConnectionRefusedError: # catch refused connection for retry
+                print("Connection to " + self.host + ":" + str(self.port) + " failed, retrying in 5s")
+                time.sleep(5)
+
+
+# The following code is used for the Mock Operator
+class CommandConnection(Connection):
+    def connect(self):
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        while(True):
+            try:
+                self.socket.bind((self.host, self.port))
+                print("Bind to socket: " + self.host + ":" + str(self.port))
+                break
+            except ConnectionRefusedError: # catch refused connection for retry
+                print("Connection to " + self.host + ":" + str(self.port) + " failed, retrying in 5s")
+                time.sleep(5)
+
+        self.accept_connections()
+
+    def accept_connections(self):
+        print("Starting to listen!")
+        self.socket.listen()
+
+        while True: 
+            # Establish connection with client. 
+            connection, address = self.socket.accept()
+            self.is_connected = True
+            print ('Got connection from', address)
+            thread = threading.Thread(target=self.listen, args=(connection,))
+            thread.start()
+
+    def listen(self, connection):
+        while True:
+            message = connection.recv(2048)
+
+            if len(message) == 0:
+                continue
+
+            print(f"RECEIVED MESSAGE: {message}")
+            command_id_bytes = message[0:4]
+            reserved_bytes = message[4:6]
+            command_value_bytes = message[6:8]
+            payload_length_bytes = message[8:10]
+            
+            payload_length = bytes_to_int(payload_length_bytes)
+            command_value = bytes_to_int(command_value_bytes)
+
+            payload_end_index = 10 + payload_length
+            payload_bytes = message[10:payload_end_index]
+            checksum_bytes = message[-2:]
+
+            return_command_value = command_value + 0x8000
+            return_command_value_bytes = int_to_bytes(return_command_value, num_bits=16, unsigned=True)
+            print("Sending return")
+            connection.send(return_command_value_bytes)

--- a/icd_config.py
+++ b/icd_config.py
@@ -32,12 +32,21 @@ def int_to_bytes(num, num_bits=16, unsigned=True):
     return bytes(reversed(bytes(c_type_int)))
 
 
+def bytes_to_int(bytes):
+    return int.from_bytes(bytes, byteorder='big')
+
+
 class Command(Enum):
     HANDSHAKE = 0x0000
+    HANDSHAKE_RETURN = 0x8000
     POLAR_PAN_DISCRETE = 0x0001
+    POLAR_PAN_DISCRETE_RETURN = 0x8001
     HOME = 0x0002
+    HOME_RETURN = 0x8002
     POLAR_PAN_CONTINUOUS_START = 0x0003
+    POLAR_PAN_CONTINUOUS_START_RETURN = 0x8003
     POLAR_PAN_CONTINUOUS_STOP = 0x0004
+    POLAR_PAN_CONTINUOUS_STOP_RETURN = 0x8004
 
     def __int__(self):
         """

--- a/mock_operator.py
+++ b/mock_operator.py
@@ -1,17 +1,85 @@
-import stomp
+from config import SOCKET_HOST, SOCKET_PORT
+from icd_config import int_to_bytes, bytes_to_int
+from publisher import Publisher, Connection
 import time
-from publisher import INSTRUCTIONS_DESTINATION
+import threading
+import socket
 
-class MyListener(stomp.ConnectionListener):
-    def on_error(self, frame):
-        print('received an error "%s"' % frame.body)
 
-    def on_message(self, frame):
-        print('received a message "%s"' % bytes(frame.body, 'utf-8'))
+class CommandConnection(Connection):
+    def connect(self):
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-conn = stomp.Connection()
-conn.set_listener(name='My listener', listener=MyListener())
-conn.connect('admin', 'admin', wait=True)
-conn.subscribe(destination=INSTRUCTIONS_DESTINATION, id=1)
-time.sleep(10)
-conn.disconnect()
+        while(True):
+            try:
+                self.socket.bind((self.host, self.port))
+                self.is_connected = True
+                print("Bind to socket: " + self.host + ":" + str(self.port))
+                break
+            except ConnectionRefusedError: # catch refused connection for retry
+                print("Connection to " + self.host + ":" + str(self.port) + " failed, retrying in 5s")
+                time.sleep(5)
+
+        self.accept_connections()
+
+    def accept_connections(self):
+        print("Starting to listen!")
+        self.socket.listen()
+
+        while True: 
+            # Establish connection with client. 
+            connection, address = self.socket.accept()
+            print ('Got connection from', address)
+            thread = threading.Thread(target=self.listen, args=(connection,))
+            thread.start()
+
+    def listen(self, connection):
+        while True:
+            message = connection.recv(2048)
+            command_id_bytes = message[0:4]
+            reserved_bytes = message[4:6]
+            command_value_bytes = message[6:8]
+            payload_length_bytes = message[8:10]
+            
+            payload_length = bytes_to_int(payload_length_bytes)
+            command_value = bytes_to_int(command_value_bytes)
+
+            payload_end_index = 10 + payload_length
+            payload_bytes = message[10:payload_end_index]
+            checksum_bytes = message[-2:]
+
+            return_command_value = command_value + 0x8000
+            return_command_value_bytes = int_to_bytes(return_command_value, num_bits=16, unsigned=True)
+            print("Sending return")
+            connection.send(return_command_value_bytes)
+
+
+class MockOperator:
+    connection = CommandConnection(host=SOCKET_HOST, port=SOCKET_PORT)
+
+    @staticmethod
+    def close_connection():
+        MockOperator.connection.close_socket()
+
+    @staticmethod
+    def send_return_code(command_id, payload):
+        MockOperator.connection.publish(
+            command=command_id,
+            payload=payload
+        )
+
+
+def create_return_payload(success):
+    return int_to_bytes(int(success), num_bits=16, unsigned=True)
+
+
+def main():
+    while (not MockOperator.connection.is_connected):
+        time.sleep(1)
+
+    print("Mock operator is connected!")
+    Publisher.home(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/mock_operator.py
+++ b/mock_operator.py
@@ -1,57 +1,7 @@
 from config import SOCKET_HOST, SOCKET_PORT
-from icd_config import int_to_bytes, bytes_to_int
-from publisher import Publisher, Connection
+from icd_config import int_to_bytes 
 import time
-import threading
-import socket
-
-
-class CommandConnection(Connection):
-    def connect(self):
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-        while(True):
-            try:
-                self.socket.bind((self.host, self.port))
-                self.is_connected = True
-                print("Bind to socket: " + self.host + ":" + str(self.port))
-                break
-            except ConnectionRefusedError: # catch refused connection for retry
-                print("Connection to " + self.host + ":" + str(self.port) + " failed, retrying in 5s")
-                time.sleep(5)
-
-        self.accept_connections()
-
-    def accept_connections(self):
-        print("Starting to listen!")
-        self.socket.listen()
-
-        while True: 
-            # Establish connection with client. 
-            connection, address = self.socket.accept()
-            print ('Got connection from', address)
-            thread = threading.Thread(target=self.listen, args=(connection,))
-            thread.start()
-
-    def listen(self, connection):
-        while True:
-            message = connection.recv(2048)
-            command_id_bytes = message[0:4]
-            reserved_bytes = message[4:6]
-            command_value_bytes = message[6:8]
-            payload_length_bytes = message[8:10]
-            
-            payload_length = bytes_to_int(payload_length_bytes)
-            command_value = bytes_to_int(command_value_bytes)
-
-            payload_end_index = 10 + payload_length
-            payload_bytes = message[10:payload_end_index]
-            checksum_bytes = message[-2:]
-
-            return_command_value = command_value + 0x8000
-            return_command_value_bytes = int_to_bytes(return_command_value, num_bits=16, unsigned=True)
-            print("Sending return")
-            connection.send(return_command_value_bytes)
+from connections import CommandConnection
 
 
 class MockOperator:
@@ -78,7 +28,6 @@ def main():
         time.sleep(1)
 
     print("Mock operator is connected!")
-    Publisher.home(0)
 
 
 if __name__ == "__main__":

--- a/publisher.py
+++ b/publisher.py
@@ -1,84 +1,7 @@
 from config import SOCKET_HOST, SOCKET_PORT
 from icd_config import Command, int_to_bytes
-import socket
+from connections import OperatorConnection
 import time
-import threading
-
-
-class Connection:
-    def __init__(self, host, port):
-        self.host = host
-        self.port = port
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.is_connected = False
-        self.async_connect()
-
-    def async_connect(self):
-        thread = threading.Thread(target=self.connect)
-        thread.start()
-
-    def connect(self):
-        raise NotImplementedError("connect method is not implemented")
-
-    def close_socket(self):
-        self.socket.close()
-        self.is_connected = False
-
-    def publish(self, command: int, payload: bytes = None):
-        """
-        Command ID      UINT32	Unique ID for individual commands
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        RESERVED     	UINT16	RESERVED
-        Command Value	UINT16	Command for device to carry out
-        Length	        UINT16	Length of Payload
-        Payload	        UINT8[]	Command Info
-        CRC	            UINT16	Checksum
-        """
-        # Get a unique, incrementing command id. Increment by 2, so that the response
-        # from the operator always returns odd command ids and the publisher always sends
-        # even command ids. Commands can be associated with each other by checking if they
-        # have the same modulus of 2.
-        command_id = Publisher.command_count
-        Publisher.command_count += 2
-
-        if payload != None:
-            payload_length = len(payload)
-        else:
-            payload_length = 0
-
-        # TODO: Implement checksum. May get removed
-        crc = int_to_bytes(0, num_bits=16, unsigned=True)
-
-        command_id = int_to_bytes(command_id, num_bits=32, unsigned=True)
-        reserved = int_to_bytes(0, num_bits=16, unsigned=True)
-        command = int_to_bytes(command, num_bits=16, unsigned=True)
-        payload_length = int_to_bytes(payload_length, num_bits=16, unsigned=True)
-
-        # Put header together
-        header = command_id + reserved + command + payload_length
-
-        # Put everything together 
-        body = header
-
-        if payload != None:
-            body += payload
-
-        body += crc
-
-        self.socket.send(body)
-
-
-class OperatorConnection(Connection):
-    def connect(self):
-        while(True):
-            try:
-                self.socket.connect((self.host, self.port))
-                self.is_connected = True
-                print("Connected to socket: " + self.host + ":" + str(self.port))
-                break
-            except ConnectionRefusedError: # catch refused connection for retry
-                print("Connection to " + self.host + ":" + str(self.port) + " failed, retrying in 5s")
-                time.sleep(5)
 
 
 class Publisher:
@@ -171,3 +94,18 @@ class Publisher:
             command=int(Command.HOME),
             payload=delay
         )
+
+
+def main():
+    while (not Publisher.connection.is_connected):
+        time.sleep(1)
+
+    Publisher.home(0)
+
+    # Stay alive
+    while True:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/publisher.py
+++ b/publisher.py
@@ -2,10 +2,13 @@ import stomp
 from icd_config import Command, int_to_bytes
 from stomp.utils import encode
 import socket
+import time
 
 
 HANDSHAKE_DESTINATION = '/queue/handshake'
 INSTRUCTIONS_DESTINATION = '/queue/instructions'
+SOCKET_HOST = 'localhost'
+SOCKET_PORT = 61616
 
 
 class Connection:
@@ -19,9 +22,16 @@ class Connection:
         #self.connection.connect('admin', 'admin', wait=True)
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.host = "localhost"
-        self.port = 61616
-        self.socket.connect((self.host, self.port))
+
+        while(True):
+            try:
+                self.socket.connect((SOCKET_HOST, SOCKET_PORT))
+                print("Connected to socket: " + SOCKET_HOST + ":" + str(SOCKET_PORT))
+                break
+            except ConnectionRefusedError: # catch refused connection for retry
+                print("Connection to " + SOCKET_HOST + ":" + str(SOCKET_PORT) + " failed, retrying in 5s")
+                time.sleep(5)
+
 
     def close_socket(self):
         self.socket.close()
@@ -66,8 +76,7 @@ class Connection:
 
         body += crc
 
-        self.socket.sendall(body)
-        #self.connection.send(body=body, destination=destination, content_type='application/octet-stream')
+        self.socket.send(body)
 
 
 class Publisher:

--- a/publisher.py
+++ b/publisher.py
@@ -1,6 +1,7 @@
 import stomp
 from icd_config import Command, int_to_bytes
 from stomp.utils import encode
+import socket
 
 
 HANDSHAKE_DESTINATION = '/queue/handshake'
@@ -14,8 +15,16 @@ class Connection:
     publisher. Also contains a function that is used to publish messages.
     """
     def __init__(self):
-        self.connection = stomp.Connection()
-        self.connection.connect('admin', 'admin', wait=True)
+        #self.connection = stomp.Connection()
+        #self.connection.connect('admin', 'admin', wait=True)
+
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.host = "localhost"
+        self.port = 61616
+        self.socket.connect((self.host, self.port))
+
+    def close_socket(self):
+        self.socket.close()
 
     def publish(self, destination, command: int, payload: bytes = None):
         """
@@ -57,7 +66,8 @@ class Connection:
 
         body += crc
 
-        self.connection.send(body=body, destination=destination, content_type='application/octet-stream')
+        self.socket.sendall(body)
+        #self.connection.send(body=body, destination=destination, content_type='application/octet-stream')
 
 
 class Publisher:
@@ -67,6 +77,9 @@ class Publisher:
     connection = Connection()
     command_count = 0
 
+    @staticmethod
+    def close_connection():
+        Publisher.connection.close_socket()
 
     @staticmethod
     def handshake():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 docopt==0.6.2
-stomp-py==8.1.2
 websocket-client==1.8.0
 abcmeta==2.2.0
 opencv-python==4.10.0.84

--- a/talos.py
+++ b/talos.py
@@ -11,6 +11,11 @@ def main():
     parser.add_argument("--source", type=str, default="", help="Path to video file or URL of stream")
     args = parser.parse_args()
 
+
+    while (not Publisher.connection.is_connected):
+        print("Waiting to connect...")
+        time.sleep(5)
+
     #interface = ManualInterface()
     #interface.launch_user_interface()
 

--- a/talos.py
+++ b/talos.py
@@ -14,19 +14,19 @@ def main():
     interface.launch_user_interface()
 
     
-    tracker = MediaPipeTracker(args.source)
-    director = BasicDirector(tracker, "./config.yaml")
+    # tracker = MediaPipeTracker(args.source)
+    # director = BasicDirector(tracker, "./config.yaml")
 
-    while True:
-        frame = tracker.capture_frame()
+    # while True:
+    #     frame = tracker.capture_frame()
 
-        #Helpful for bounding boxes on screen, this can be removed later
-        if cv2.waitKey(1) & 0xFF == ord('q'):
-            break
+    #     #Helpful for bounding boxes on screen, this can be removed later
+    #     if cv2.waitKey(1) & 0xFF == ord('q'):
+    #         break
 
-        if frame is None:
-            break
-        director.process_frame(frame)
+    #     if frame is None:
+    #         break
+    #     director.process_frame(frame)
     
 
 

--- a/talos.py
+++ b/talos.py
@@ -6,28 +6,36 @@ import cv2
 from manual_interface import ManualInterface
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--source", type=str, default="", help="Path to video file or URL of stream")
-    args = parser.parse_args()
 
-    interface = ManualInterface()
-    interface.launch_user_interface()
+    try:
 
-    
-    # tracker = MediaPipeTracker(args.source)
-    # director = BasicDirector(tracker, "./config.yaml")
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--source", type=str, default="", help="Path to video file or URL of stream")
+        args = parser.parse_args()
 
-    # while True:
-    #     frame = tracker.capture_frame()
+        interface = ManualInterface()
+        interface.launch_user_interface()
 
-    #     #Helpful for bounding boxes on screen, this can be removed later
-    #     if cv2.waitKey(1) & 0xFF == ord('q'):
-    #         break
 
-    #     if frame is None:
-    #         break
-    #     director.process_frame(frame)
-    
+        # tracker = MediaPipeTracker(args.source)
+        # director = BasicDirector(tracker, "./config.yaml")
+
+        # while True:
+        #     frame = tracker.capture_frame()
+
+        #     #Helpful for bounding boxes on screen, this can be removed later
+        #     if cv2.waitKey(1) & 0xFF == ord('q'):
+        #         break
+
+        #     if frame is None:
+        #         break
+        #     director.process_frame(frame)
+    except KeyboardInterrupt:
+        print("Exception caught, exiting gracefully...")
+        Publisher.close_connection()
+    except Exception:
+        print("Exception caught, exiting gracefully...")
+        Publisher.close_connection()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Migrate away from ActiveMQ and use sockets instead.

Added a Mock Operator that listens for requests and then always responds with a success message for that corresponding command.

Created a config file to store some global python values.

Refactored to create a basic `Connection` class that can be inherited.

# Metrics
- PR Confidence value: 8

closes #54 
