### PR TITLE
Issue #77: Add set speed command to publisher

### DIFF
--- a/icd_config.py
+++ b/icd_config.py
@@ -47,6 +47,8 @@ class Command(Enum):
     POLAR_PAN_CONTINUOUS_START_RETURN = 0x8003
     POLAR_PAN_CONTINUOUS_STOP = 0x0004
     POLAR_PAN_CONTINUOUS_STOP_RETURN = 0x8004
+    SET_SPEED = 0x0005
+    SET_SPEED_RETURN = 0x8005
 
     def __int__(self):
         """

--- a/publisher.py
+++ b/publisher.py
@@ -96,6 +96,22 @@ class Publisher:
         )
 
 
+    @staticmethod
+    def set_speed(speed: int, axis: int):
+        """
+        Speed 	UINT8 	What to set the speed of all axes to on the scorbot
+        Axis 	UINT8 	Axis to change (for all axes send 0)
+        """
+        speed_bytes = int_to_bytes(speed, num_bits=8, unsigned=True)
+        axis_bytes = int_to_bytes(axis, num_bits=8, unsigned=True)
+        payload = speed_bytes + axis_bytes
+
+        Publisher.connection.publish(
+            command=Command.SET_SPEED,
+            payload=payload
+        )
+
+
 def main():
     while (not Publisher.connection.is_connected):
         time.sleep(1)


### PR DESCRIPTION
# Description
Added the Set Speed command to the publisher, as specified by the Talos ICD.

# Metrics
- PR Confidence value: 5/5

closes #77 